### PR TITLE
Use `AsMut<[u8]>` implementation instead of slices

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -35,7 +35,7 @@ mod octavo {
         let mut out = [0u8; 20];
         let mut ctx = digest::sha1::Sha1::default();
         ctx.update(&input);
-        ctx.result(&mut out[..]);
+        ctx.result(&mut out);
     });
 
     digest_benches!(sha256, ring::digest::SHA256.block_len, input, {
@@ -44,7 +44,7 @@ mod octavo {
         let mut out = [0u8; 32];
         let mut ctx = digest::sha2::Sha256::default();
         ctx.update(&input);
-        ctx.result(&mut out[..]);
+        ctx.result(&mut out);
     });
 
     digest_benches!(sha384, ring::digest::SHA384.block_len, input, {


### PR DESCRIPTION
This speeds up Octavo results by order of magnitude. Unfortunately it is still impossible to use in case of SHA512 as there is no implementation of `AsMut<[u8]>` for `&mut [_; 64]`.