### PR TITLE
Added SHA-256/512 and salsa20-poly1305 benches for sodiumoxide.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+install:
+  # libsodium is not yet whitelisted for use via the TravisCI apt addon, so we install it manually
+  - wget https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz
+  - tar xvfz libsodium-1.0.10.tar.gz
+  - cd libsodium-1.0.10 && ./configure --prefix=$HOME/installed_libsodium && make && make install && cd ..
+  - export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
+  - export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
+
 script:
   # We don't run `cargo bench` because Travis CI isn't a reliable platform for
   # measuring performance. We run `cargo test` to ensure that changes do not

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Benchmarks for Rust crypto libraries
 
 |                                              |       *ring*       |       Octavo       |     rust-crypto    | rust-nettle (Nettle) | rust-openssl (OpenSSL) | sodiumoxide (libsodium) | Windows CNG | Mac/iOS Common Crypto |
 |----------------------------------------------|:------------------:|:------------------:|:------------------:|----------------------|:----------------------:|:-----------------------:|:-----------:|:---------------------:|
-| SHA&#x2011;1 & SHA&#x2011;2                  | :white_check_mark: | :white_check_mark: | :white_check_mark: |                      | :white_check_mark:     | SHA-256/512 only        |             |                       |
+| SHA&#x2011;1 & SHA&#x2011;2                  | :white_check_mark: | :white_check_mark: | :white_check_mark: |                      | :white_check_mark:     | SHA-{256,512} only      |             |                       |
 | HMAC (SHA&#x2011;1 & SHA&#x2011;2)           |                    |                    |                    |                      |                        |                         |             |                       |
 | PBKDF2 (SHA&#x2011;1 & SHA&#x2011;2)         | :white_check_mark: |                    | :white_check_mark: |                      | SHA-1 only             |                         |             |                       |
 | AES&#x2011;128&#x2011;GCM & AES&#x2011;256&#x2011;GCM | :white_check_mark: |           | :white_check_mark: |                      |                        |                         |             |                       |
-| ChaCha20&#x2011;Poly1305                     | :white_check_mark: |                    | :white_check_mark: |                      |                        | Salsa20&#x2011;Poly1305 |             |                       |
+| ChaCha20&#x2011;Poly1305                     | :white_check_mark: |                    | :white_check_mark: |                      |                        |                         |             |                       |
+| Salsa20&#x2011;Poly1305                      |                    |                    |                    |                      |                        | :white_check_mark:      |             |                       |
 | ECDH (Suite B) key exchange                  | :white_check_mark: |                    |                    |                      |                        |                         |             |                       |
 | X25519 (Curve25519) key exchange             | :white_check_mark: |                    |                    |                      |                        |                         |             |                       |
 | Random Byte Generation                       |                    |                    |                    |                      |                        |                         |             |                       |

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Benchmarks for Rust crypto libraries
 
 |                                              |       *ring*       |       Octavo       |     rust-crypto    | rust-nettle (Nettle) | rust-openssl (OpenSSL) | sodiumoxide (libsodium) | Windows CNG | Mac/iOS Common Crypto |
 |----------------------------------------------|:------------------:|:------------------:|:------------------:|----------------------|:----------------------:|:-----------------------:|:-----------:|:---------------------:|
-| SHA&#x2011;1 & SHA&#x2011;2                  | :white_check_mark: | :white_check_mark: | :white_check_mark: |                      | :white_check_mark:     |                         |             |                       |
+| SHA&#x2011;1 & SHA&#x2011;2                  | :white_check_mark: | :white_check_mark: | :white_check_mark: |                      | :white_check_mark:     | SHA-256/512 only        |             |                       |
 | HMAC (SHA&#x2011;1 & SHA&#x2011;2)           |                    |                    |                    |                      |                        |                         |             |                       |
 | PBKDF2 (SHA&#x2011;1 & SHA&#x2011;2)         | :white_check_mark: |                    | :white_check_mark: |                      | SHA-1 only             |                         |             |                       |
 | AES&#x2011;128&#x2011;GCM & AES&#x2011;256&#x2011;GCM | :white_check_mark: |           | :white_check_mark: |                      |                        |                         |             |                       |
-| ChaCha20&#x2011;Poly1305                     | :white_check_mark: |                    | :white_check_mark: |                      |                        |                         |             |                       |
+| ChaCha20&#x2011;Poly1305                     | :white_check_mark: |                    | :white_check_mark: |                      |                        | Salsa20&#x2011;Poly1305 |             |                       |
 | ECDH (Suite B) key exchange                  | :white_check_mark: |                    |                    |                      |                        |                         |             |                       |
 | X25519 (Curve25519) key exchange             | :white_check_mark: |                    |                    |                      |                        |                         |             |                       |
 | Random Byte Generation                       |                    |                    |                    |                      |                        |                         |             |                       |
@@ -92,6 +92,7 @@ pull request.
 * `(cd openssl && cargo bench)` runs all the tests for [rust-openssl](https://github.com/sfackler/rust-openssl).
 * `(cd ring && cargo bench)` runs all the tests for [*ring*](https://github.com/briansmith/ring).
 * `(cd rust_crypto && cargo bench)` runs all the tests for [rust-crypto](https://github.com/DaGenix/rust-crypto).
+* `(cd sodiumoxide && cargo bench)` runs all the tests for [sodiumoxide](https://github.com/dnaq/sodiumoxide).
 
 
 

--- a/cargo_all
+++ b/cargo_all
@@ -5,3 +5,4 @@
 (cd openssl && cargo $*)
 (cd ring && cargo $*)
 (cd rust_crypto && cargo $*)
+(cd sodiumoxide && cargo $*)

--- a/cargo_all.bat
+++ b/cargo_all.bat
@@ -17,3 +17,7 @@ POPD
 PUSHD rust_crypto
 cargo %*
 POPD
+
+PUSHD sodiumoxide
+cargo %*
+POPD

--- a/sodiumoxide/Cargo.toml
+++ b/sodiumoxide/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "crypto_bench_sodiumoxide"
+version = "0.1.0"
+
+[lib]
+name = "crypto_bench_sodiumoxide"
+path = "sodiumoxide.rs"
+
+[dependencies.crypto_bench]
+path = "../crypto_bench"
+
+[dependencies]
+sodiumoxide = "0.0.10"
+
+# Ensure that the bench, release, and test settings are the same.
+
+[profile.bench]
+opt-level = 3
+debug = true
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+
+[profile.release]
+opt-level = 3
+debug = true
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+
+[profile.test]
+opt-level = 3
+debug = true
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1

--- a/sodiumoxide/sodiumoxide.rs
+++ b/sodiumoxide/sodiumoxide.rs
@@ -1,0 +1,58 @@
+#![feature(test)]
+
+extern crate test;
+
+#[macro_use]
+extern crate crypto_bench;
+
+extern crate sodiumoxide;
+
+mod digest {
+    macro_rules! sodiumoxide_digest_benches {
+        ( $name:ident, $block_len:expr, $output_len:expr, $digester:path) => {
+            mod $name {
+                use crypto_bench;
+                use $digester;
+
+                digest_benches!($block_len, input, {
+                    hash(&input)
+                });
+            }
+        }
+    }
+
+    sodiumoxide_digest_benches!(sha256, crypto_bench::SHA256_BLOCK_LEN,
+                         crypto_bench::SHA256_OUTPUT_LEN,
+                         sodiumoxide::crypto::hash::sha256::hash);
+    sodiumoxide_digest_benches!(sha512, crypto_bench::SHA512_BLOCK_LEN,
+                         crypto_bench::SHA512_OUTPUT_LEN,
+                         sodiumoxide::crypto::hash::sha512::hash);
+}
+
+mod aead {
+    use test;
+
+    macro_rules! sodiumoxide_aead_bench {
+        ( $benchmark_name:ident, $input_len:expr, $sealer:path ) => {
+            #[bench]
+            fn $benchmark_name(b: &mut test::Bencher) {
+                use $sealer;
+                use sodiumoxide::crypto::secretbox;
+                b.bytes = $input_len;
+                let key = secretbox::gen_key();
+                let nonce = secretbox::gen_nonce();
+                let plaintext = [0u8; $input_len];
+                b.iter(|| {
+                    seal(&plaintext, &nonce, &key)
+                });
+            }
+        }
+    }
+
+    sodiumoxide_aead_bench!(xsalsa20poly1305_16, 16,
+                    sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
+    sodiumoxide_aead_bench!(xsalsa20poly1305_1350, 1350,
+                    sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
+    sodiumoxide_aead_bench!(xsalsa20poly1305_8192, 8192,
+                    sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
+}

--- a/sodiumoxide/sodiumoxide.rs
+++ b/sodiumoxide/sodiumoxide.rs
@@ -21,12 +21,12 @@ mod digest {
         }
     }
 
-    sodiumoxide_digest_benches!(sha256, crypto_bench::SHA256_BLOCK_LEN,
-                         crypto_bench::SHA256_OUTPUT_LEN,
-                         sodiumoxide::crypto::hash::sha256::hash);
-    sodiumoxide_digest_benches!(sha512, crypto_bench::SHA512_BLOCK_LEN,
-                         crypto_bench::SHA512_OUTPUT_LEN,
-                         sodiumoxide::crypto::hash::sha512::hash);
+    sodiumoxide_digest_benches!(
+        sha256, crypto_bench::SHA256_BLOCK_LEN, crypto_bench::SHA256_OUTPUT_LEN,
+        sodiumoxide::crypto::hash::sha256::hash);
+    sodiumoxide_digest_benches!(
+        sha512, crypto_bench::SHA512_BLOCK_LEN, crypto_bench::SHA512_OUTPUT_LEN,
+        sodiumoxide::crypto::hash::sha512::hash);
 }
 
 mod aead {
@@ -49,10 +49,13 @@ mod aead {
         }
     }
 
-    sodiumoxide_aead_bench!(xsalsa20poly1305_16, 16,
-                    sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
-    sodiumoxide_aead_bench!(xsalsa20poly1305_1350, 1350,
-                    sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
-    sodiumoxide_aead_bench!(xsalsa20poly1305_8192, 8192,
-                    sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
+    sodiumoxide_aead_bench!(
+        xsalsa20poly1305_16, 16,
+        sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
+    sodiumoxide_aead_bench!(
+        xsalsa20poly1305_1350, 1350,
+        sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
+    sodiumoxide_aead_bench!(
+        xsalsa20poly1305_8192, 8192,
+        sodiumoxide::crypto::secretbox::xsalsa20poly1305::seal);
 }

--- a/sodiumoxide/sodiumoxide.rs
+++ b/sodiumoxide/sodiumoxide.rs
@@ -41,9 +41,18 @@ mod aead {
                 b.bytes = $input_len;
                 let key = secretbox::gen_key();
                 let nonce = secretbox::gen_nonce();
-                let plaintext = [0u8; $input_len];
+                let mut plaintext = vec![0u8; $input_len];
                 b.iter(|| {
-                    seal(&plaintext, &nonce, &key)
+                    let out = seal(&plaintext, &nonce, &key);
+                    // XXX: secretbox doesn't support in place encryption, so
+                    // fake it until we change this to use the aead encrypt
+                    // function directly.
+                    // out is a bit larger than plaintext. This ignores the
+                    // bytes in the mismatch.
+                    for i in 0..plaintext.len() {
+                        plaintext[i] = out[i];
+                    }
+                    out
                 });
             }
         }


### PR DESCRIPTION
sodiumoxide doesn't support additional data, nor does it support AES-GCM. I don't see a reason for these gaps other than lack of interest. I'll take a crack at at least AES-GCM since that seems broadly useful outside of benchmarking. If you think the missing additional data support is hurting the benchmark comparison I'd be happy to take a crack at that too.

ring beats sodiumoxide by ~2x on SHA-512 on my laptop (Haswell i7 MacBook Pro).

Partially fixes #13 