### PR TITLE
Fix building openssl on ARM

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -11,7 +11,7 @@ path = "openssl.rs"
 path = "../crypto_bench"
 
 [dependencies]
-openssl = "0.6"
+openssl = "0.7"
 
 # Ensure that the bench, release, and test settings are the same.
 


### PR DESCRIPTION
The [issue](https://github.com/rust-lang/rust/issues/29867) was fixed in openssl 0.7