### PR TITLE
Upgrade OpenSSL benchmarks to 0.9.x

### DIFF
--- a/openssl/openssl.rs
+++ b/openssl/openssl.rs
@@ -8,10 +8,10 @@ extern crate crypto_bench;
 extern crate openssl;
 
 macro_rules! openssl_digest_benches {
-    ( $name:ident, $block_len:expr, $alg:expr) => {
+    ( $name:ident, $block_len:expr, $alg:expr ) => {
         mod $name {
             use crypto_bench;
-            use openssl::crypto::hash;
+            use openssl::hash;
 
             digest_benches!($block_len, input, {
                 let _ = hash::hash($alg, input);
@@ -22,13 +22,13 @@ macro_rules! openssl_digest_benches {
 
 mod digest {
     openssl_digest_benches!(sha1, crypto_bench::SHA1_BLOCK_LEN,
-                            hash::Type::SHA1);
+                            hash::MessageDigest::sha1());
     openssl_digest_benches!(sha256, crypto_bench::SHA256_BLOCK_LEN,
-                            hash::Type::SHA256);
+                            hash::MessageDigest::sha256());
     openssl_digest_benches!(sha384, crypto_bench::SHA384_BLOCK_LEN,
-                            hash::Type::SHA384);
+                            hash::MessageDigest::sha384());
     openssl_digest_benches!(sha512, crypto_bench::SHA512_BLOCK_LEN,
-                            hash::Type::SHA512);
+                            hash::MessageDigest::sha512());
 }
 
 mod pbkdf2 {
@@ -37,11 +37,10 @@ mod pbkdf2 {
     use test;
 
     pbkdf2_bench!(hmac_sha1, 20, out, {
-        let vec = openssl::crypto::pkcs5::pbkdf2_hmac_sha1(
-                    &crypto_bench::pbkdf2::PASSWORD_STR, &crypto_bench::pbkdf2::SALT,
-                    crypto_bench::pbkdf2::ITERATIONS as usize, out.len());
-        for i in 0..out.len() {
-            out[i] = vec[i];
-        }
+        openssl::pkcs5::pbkdf2_hmac(crypto_bench::pbkdf2::PASSWORD_STR.as_bytes(),
+                                    &crypto_bench::pbkdf2::SALT,
+                                    crypto_bench::pbkdf2::ITERATIONS as usize,
+                                    openssl::hash::MessageDigest::sha1(),
+                                    &mut out);
     });
 }


### PR DESCRIPTION
I believe the existing OpenSSL implementation was using rust-openssl 0.7.x syntax.