### PR TITLE
Add x25519 bench for sodiumoxide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Benchmarks for Rust crypto libraries
 | ChaCha20&#x2011;Poly1305                     | :white_check_mark: | :white_check_mark: |                      |                        |                         |             |                       |
 | Salsa20&#x2011;Poly1305                      |                    |                    |                      |                        | :white_check_mark:      |             |                       |
 | ECDH (Suite B) key exchange                  | :white_check_mark: |                    |                      |                        |                         |             |                       |
-| X25519 (Curve25519) key exchange             | :white_check_mark: | :white_check_mark: |                      |                        |                         |             |                       |
+| X25519 (Curve25519) key exchange             | :white_check_mark: | :white_check_mark: |                      |                        | :white_check_mark:      |             |                       |
 | Random Byte Generation                       |                    |                    |                      |                        |                         |             |                       |
 | ECDSA (Suite B) signature verification       | In Progress (@briansmith) |             |                      |                        |                         |             |                       |
 | Ed25519 signature verification               | In Progress (@briansmith) | In Progress (@briansmith) |        |                        |                         |             |                       |

--- a/sodiumoxide/sodiumoxide.rs
+++ b/sodiumoxide/sodiumoxide.rs
@@ -7,6 +7,57 @@ extern crate crypto_bench;
 
 extern crate sodiumoxide;
 
+mod agreement {
+    mod x25519 {
+        use sodiumoxide::init;
+        use sodiumoxide::randombytes::randombytes_into;
+        use sodiumoxide::crypto::scalarmult;
+        use test::Bencher;
+
+        #[bench]
+        fn generate_key_pair(b: &mut Bencher) {
+            init();
+
+            b.iter(|| {
+                let mut k = [0; scalarmult::SCALARBYTES];
+                randombytes_into(&mut k[..]);
+                let s = scalarmult::Scalar(k);
+
+                scalarmult::scalarmult_base(&s)
+            });
+        }
+
+        #[bench]
+        fn generate_private_key(b: &mut Bencher) {
+            init();
+
+            b.iter(|| {
+                let mut k = [0; scalarmult::SCALARBYTES];
+                randombytes_into(&mut k[..]);
+                scalarmult::Scalar(k)
+            });
+        }
+
+        #[bench]
+        fn generate_key_pair_and_agree_ephemeral(b: &mut Bencher) {
+            init();
+
+            let mut k = [0; scalarmult::SCALARBYTES];
+            randombytes_into(&mut k[..]);
+            let s = scalarmult::Scalar(k);
+
+            b.iter(|| {
+                let mut k1 = [0; scalarmult::SCALARBYTES];
+                randombytes_into(&mut k1[..]);
+                let s1 = scalarmult::Scalar(k1);
+                let e1 = scalarmult::scalarmult_base(&s1);
+
+                scalarmult::scalarmult(&s, &e1)
+            });
+        }
+    }
+}
+
 mod digest {
     macro_rules! sodiumoxide_digest_benches {
         ( $name:ident, $block_len:expr, $output_len:expr, $digester:path) => {


### PR DESCRIPTION
Add x25519 benchmarks for sodiumoxide.

Sodiumoxide is slightly faster than _ring_ on my computer (Intel Haswell Xeon E3).

It's worth mentioning that calling `sodiumoxide::init()` makes a notable difference. Other benchmarks for sodiumoxide should probably do the same.