### PR TITLE
Fix *ring* benchmarks

### DIFF
--- a/ring/aead.rs
+++ b/ring/aead.rs
@@ -17,7 +17,7 @@ fn seal_in_place_bench(algorithm: &'static aead::Algorithm,
                        rng: &SecureRandom,
                        chunk_len: usize, ad: &[u8],
                        b: &mut test::Bencher) {
-    let out_suffix_capacity = algorithm.max_overhead_len();
+    let out_suffix_capacity = algorithm.tag_len();
     let mut in_out = vec![0u8; chunk_len + out_suffix_capacity];
 
     // XXX: This is a little misleading when `ad` isn't empty.

--- a/ring/aead.rs
+++ b/ring/aead.rs
@@ -25,9 +25,10 @@ fn seal_in_place_bench(algorithm: &'static aead::Algorithm,
 
     let key = generate_sealing_key(algorithm, rng).unwrap();
     b.iter(|| {
-        aead::seal_in_place(&key, &crypto_bench::aead::NONCE,
-                            &mut in_out, out_suffix_capacity,
-                            ad).unwrap();
+        aead::seal_in_place(&key, &crypto_bench::aead::NONCE, ad, &mut in_out,
+                            out_suffix_capacity).unwrap();
+
+
     });
 }
 

--- a/ring/ring.rs
+++ b/ring/ring.rs
@@ -115,13 +115,13 @@ mod pbkdf2 {
 
     pbkdf2_bench!(hmac_sha256, crypto_bench::SHA256_OUTPUT_LEN, out,
                   pbkdf2::derive(&pbkdf2::HMAC_SHA256,
-                                 crypto_bench::pbkdf2::ITERATIONS as usize,
+                                 crypto_bench::pbkdf2::ITERATIONS,
                                  &crypto_bench::pbkdf2::SALT,
                                  crypto_bench::pbkdf2::PASSWORD, &mut out));
 
     pbkdf2_bench!(hmac_sha512, crypto_bench::SHA512_OUTPUT_LEN, out,
                   pbkdf2::derive(&pbkdf2::HMAC_SHA512,
-                                 crypto_bench::pbkdf2::ITERATIONS as usize,
+                                 crypto_bench::pbkdf2::ITERATIONS,
                                  crypto_bench::pbkdf2::SALT,
                                  crypto_bench::pbkdf2::PASSWORD, &mut out));
 }


### PR DESCRIPTION
The *ring* benchmarks were broken to recent updates to the PBKDF2 and AEAD interfaces. The relevant commits are:
- https://github.com/briansmith/ring/commit/8a655e45fc0e7926db3932677a82e875bc559ce6
- https://github.com/briansmith/ring/commit/86377e6a34916f87ca890a0561bc2bf3ce5efd1a
- https://github.com/briansmith/ring/commit/a9bbd302bba0b3012407d3a084c3f2116b624bd0

This PR just updates the impacted function calls for *ring*.