### PR TITLE
Update for latest *ring*.

### DIFF
--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -10,7 +10,7 @@ path = "ring.rs"
 [dependencies]
 crypto_bench = { path = "../crypto_bench" }
 ring = { git = "https://github.com/briansmith/ring" }
-untrusted = "0.3.2"
+untrusted = "0.5.0"
 
 # Ensure that the bench, release, and test settings are the same.
 

--- a/ring/ring.rs
+++ b/ring/ring.rs
@@ -148,7 +148,7 @@ mod signature {
             let key_pair = signature::Ed25519KeyPair::generate(&rng).unwrap();
             b.iter(|| {
                 let signature = key_pair.sign(b"");
-                let _ = signature.as_slice();
+                let _ = signature.as_ref();
             });
         }
     }


### PR DESCRIPTION
This unbreaks the *ring* benchmarks for >= 0.8.