### PR TITLE
changes needed for rustc 1.36

### DIFF
--- a/fastpbkdf2/fastpbkdf2.rs
+++ b/fastpbkdf2/fastpbkdf2.rs
@@ -15,18 +15,18 @@ mod pbkdf2 {
     pbkdf2_bench!(hmac_sha1, crypto_bench::SHA1_OUTPUT_LEN, out,
                   fastpbkdf2::pbkdf2_hmac_sha1(crypto_bench::pbkdf2::PASSWORD,
                                                crypto_bench::pbkdf2::SALT,
-                                               crypto_bench::pbkdf2::ITERATIONS,
+                                               crypto_bench::pbkdf2::ITERATIONS.into(),
                                                &mut out));
 
     pbkdf2_bench!(hmac_sha256, crypto_bench::SHA256_OUTPUT_LEN, out,
                   fastpbkdf2::pbkdf2_hmac_sha256(crypto_bench::pbkdf2::PASSWORD,
                                                  crypto_bench::pbkdf2::SALT,
-                                                 crypto_bench::pbkdf2::ITERATIONS,
+                                                 crypto_bench::pbkdf2::ITERATIONS.into(),
                                                  &mut out));
 
     pbkdf2_bench!(hmac_sha512, crypto_bench::SHA512_OUTPUT_LEN, out,
                   fastpbkdf2::pbkdf2_hmac_sha512(crypto_bench::pbkdf2::PASSWORD,
                                                  crypto_bench::pbkdf2::SALT,
-                                                 crypto_bench::pbkdf2::ITERATIONS,
+                                                 crypto_bench::pbkdf2::ITERATIONS.into(),
                                                  &mut out));
 }

--- a/openssl/openssl.rs
+++ b/openssl/openssl.rs
@@ -37,10 +37,11 @@ mod pbkdf2 {
     use test;
 
     pbkdf2_bench!(hmac_sha256, 20, out, {
+        let iterations: u32 = crypto_bench::pbkdf2::ITERATIONS.into();
         let _ = openssl::pkcs5::pbkdf2_hmac(
                     crypto_bench::pbkdf2::PASSWORD, 
                     &crypto_bench::pbkdf2::SALT,
-                    crypto_bench::pbkdf2::ITERATIONS as usize, 
+                    iterations as usize,
                     openssl::hash::MessageDigest::sha256(),
                     &mut out);
     });

--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -10,4 +10,4 @@ path = "ring.rs"
 
 [dependencies]
 crypto_bench = { path = "../crypto_bench" }
-ring = "0.15.0-alpha6"
+ring = "0.16.11"

--- a/ring/aead.rs
+++ b/ring/aead.rs
@@ -48,7 +48,7 @@ fn seal_in_place_bench(
     let mut key = generate_sealing_key(algorithm, rng).unwrap();
     b.iter(|| {
         let aad = aead::Aad::from(aad);
-        key.seal_in_place(aad, &mut in_out, out_suffix_capacity)
+        key.seal_in_place_append_tag(aad, &mut in_out)
             .unwrap();
     });
 }

--- a/rust_crypto/rust_crypto.rs
+++ b/rust_crypto/rust_crypto.rs
@@ -107,21 +107,21 @@ mod pbkdf2 {
         let mut mac = hmac::Hmac::new(sha1::Sha1::new(),
                                       &crypto_bench::pbkdf2::PASSWORD);
         pbkdf2::pbkdf2(&mut mac, &crypto_bench::pbkdf2::SALT,
-                       crypto_bench::pbkdf2::ITERATIONS, &mut out);
+                       crypto_bench::pbkdf2::ITERATIONS.into(), &mut out);
     });
 
     pbkdf2_bench!(hmac_sha256, 32, out, {
         let mut mac = hmac::Hmac::new(sha2::Sha256::new(),
                                       &crypto_bench::pbkdf2::PASSWORD);
         pbkdf2::pbkdf2(&mut mac, &crypto_bench::pbkdf2::SALT,
-                       crypto_bench::pbkdf2::ITERATIONS, &mut out);
+                       crypto_bench::pbkdf2::ITERATIONS.into(), &mut out);
     });
 
     pbkdf2_bench!(hmac_sha512, 64, out, {
         let mut mac = hmac::Hmac::new(sha2::Sha512::new(),
                                       &crypto_bench::pbkdf2::PASSWORD);
         pbkdf2::pbkdf2(&mut mac, &crypto_bench::pbkdf2::SALT,
-                       crypto_bench::pbkdf2::ITERATIONS, &mut out);
+                       crypto_bench::pbkdf2::ITERATIONS.into(), &mut out);
     });
 }
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

Today I cloned crypto-bench and it did not compile.
I think this is because of rustc 1.36

```
ignisvulpis@namenlos:~/development/crypto-bench$ rustc --version
rustc 1.36.0 (a53f9df32 2019-07-03)
```